### PR TITLE
Abacus 2.0: Column titles and actual values are mixed up on the Entity Details page.

### DIFF
--- a/src/containers/Client/Client.tsx
+++ b/src/containers/Client/Client.tsx
@@ -66,9 +66,9 @@ const Client = () => {
     () =>
       entityAttributes?.reduce((acc: TableData[], item): TableData[] => {
         const transformedItem = Object.entries(item).flatMap(([key, values]) =>
-          values.map((value) => ({
-            attribute: key,
-            entityId: value,
+          values.map((attribute) => ({
+            attribute,
+            entityId: key,
           })),
         );
 

--- a/src/containers/Client/ClientTable.tsx
+++ b/src/containers/Client/ClientTable.tsx
@@ -50,4 +50,6 @@ const ClientTable: FC<Props> = (props) => {
   );
 };
 
+ClientTable.displayName = 'ClientTable';
+
 export default ClientTable;

--- a/src/containers/Entitlements/ClientsTable.tsx
+++ b/src/containers/Entitlements/ClientsTable.tsx
@@ -52,4 +52,6 @@ const ClientsTable: FC<Props> = (props) => {
   );
 };
 
+ClientsTable.displayName = 'ClientsTable';
+
 export default ClientsTable;

--- a/src/containers/User/User.tsx
+++ b/src/containers/User/User.tsx
@@ -69,9 +69,9 @@ const User = () => {
         () =>
             entityAttributes?.reduce((acc: TableData[], item): TableData[] => {
                 const transformedItem = Object.entries(item).flatMap(([key, values]) =>
-                    values.map((value) => ({
-                        attribute: key,
-                        entityId: value,
+                    values.map((attribute) => ({
+                        attribute,
+                        entityId: key,
                     })),
                 );
 
@@ -113,5 +113,7 @@ const User = () => {
         </section>
     );
 };
+
+User.displayName = 'User';
 
 export default User;


### PR DESCRIPTION
## Ticket: https://virtru.atlassian.net/browse/PLAT-1708
## Changelog:
- fix data mismatch;
- add displayName for React devtools convenience