### PR TITLE
Small fix for client list loading, but not user list

### DIFF
--- a/src/containers/Entitlements/Entitlements.tsx
+++ b/src/containers/Entitlements/Entitlements.tsx
@@ -31,7 +31,7 @@ const Entitlements = () => {
       });
 
     keyCloakClient
-      .get(`/admin/realms/${window.SERVER_DATA.realms}/users`, {
+      .get(`/admin/realms/${keycloakConfig.realm}/users`, {
         cancelToken: token,
       })
       .then((res) => {


### PR DESCRIPTION
- In DCR, client list was loading up
- User list would get stuck - seemed to be ignoring Realm selection.
- We were fetching the realm differently for the user list
- Change User list fetch to use the same method as the client list