### PR TITLE
Abacus 2.0: Sort Attributes by Values fails with 422 error.

### DIFF
--- a/src/containers/Attributes/components/AttributesHeader/AttributesHeader.tsx
+++ b/src/containers/Attributes/components/AttributesHeader/AttributesHeader.tsx
@@ -16,7 +16,7 @@ const ORDER_MAP = new Map([
   [ORDER.DES, '-'],
 ]);
 
-const SORT_OPTIONS = ['name', 'id', 'rule', 'values'];
+const SORT_OPTIONS = ['name', 'id', 'rule', 'values_array'];
 
 const CASCADER_OPTIONS = [
   {
@@ -106,5 +106,7 @@ const AttributesHeader = ({ total }: AttributesHeaderProps) => {
     </div>
   );
 };
+
+AttributesHeader.displayName = 'AttributesHeader';
 
 export default AttributesHeader;


### PR DESCRIPTION
## Ticket: https://virtru.atlassian.net/browse/PLAT-1746
### Changelog:
- fix filtering value;
- add displayName for devtools;