### PR TITLE
Abacus 2.0: Wrong column title and misaligned table columns are present on the Entitlements page.

### DIFF
--- a/src/containers/Entitlements/ClientsTable.tsx
+++ b/src/containers/Entitlements/ClientsTable.tsx
@@ -14,8 +14,18 @@ const ClientsTable: FC<Props> = (props) => {
 
   const columns = useMemo(
     () => [
-      { title: "Client id", key: "clientId", dataIndex: "clientId" },
-      { title: "ID", key: "id", dataIndex: "id" },
+      {
+        title: "Client",
+        key: "clientId",
+        dataIndex: "clientId",
+        width: '33.3%',
+      },
+      {
+        title: "ID",
+        key: "id",
+        dataIndex: "id",
+        width: '33.3%',
+      },
       {
         title: "enabled",
         key: "enabled",

--- a/src/containers/Entitlements/UsersTable.tsx
+++ b/src/containers/Entitlements/UsersTable.tsx
@@ -14,8 +14,18 @@ const UsersTable: FC<Props> = (props) => {
 
   const columns = useMemo(
     () => [
-      { title: "Username", key: "username", dataIndex: "username" },
-      { title: "ID", key: "id", dataIndex: "id" },
+      {
+        title: "Username",
+        key: "username",
+        dataIndex: "username",
+        width: '33.3%',
+      },
+      {
+        title: "ID",
+        key: "id",
+        dataIndex: "id",
+        width: '33.3%',
+      },
       {
         title: "enabled",
         key: "enabled",


### PR DESCRIPTION
## Ticket: https://virtru.atlassian.net/browse/PLAT-1760
### Changelog:
- adjust columns size and names;