### PR TITLE
abacus-localhost

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_SERVER_DATA={'attributes':'http://localhost:65432/api/attributes','entitlements':'http://localhost:65432/api/entitlements','authority':'http://localhost:65432/auth/','clientId':'dcr-test','access':'http://localhost:65432/api/kas','realms':'tdf', 'basePath':''}
+REACT_APP_SERVER_DATA={'attributes':'http://localhost:65432/api/attributes','entitlements':'http://localhost:65432/api/entitlements','authority':'http://localhost:65432/auth/','clientId':'abacus-localhost','access':'http://localhost:65432/api/kas','realms':'tdf', 'basePath':''}


### PR DESCRIPTION
Updates the the developer server to use `abacus-localhost`.  Update is in `.env`

Corresponding backend PR https://github.com/opentdf/backend/pull/219