### PR TITLE
🔨 Modernize default ingress

### DIFF
--- a/charts/abacus/values.yaml
+++ b/charts/abacus/values.yaml
@@ -61,13 +61,18 @@ ingress:
   enabled: true
   className: ""
   annotations:
-   kubernetes.io/ingress.class: nginx
-  # kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    kubernetes.io/ingress.class:
+  className: nginx
   hosts:
     - host: localhost
-      paths:
-        - path: /
+      paths: &paths
+        - path: /(.*)
           pathType: Prefix
+    - host: host.docker.internal
+      paths: *paths
+    - host: opentdf.local
+      paths: *paths
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
- Matches backend config by default, including prefix routing and names
- Uses the className parameter to set ingressClassName instead of ingress.class annotation when appropriate
- Adds `host.docker.internal` alias, useful for local development
- The `rewrite-target` annotation harmonizes the config with the other default configs in opentdf/backend