### PR TITLE
Unpriv and globals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY craco.config.js/ .
 RUN npm run build
 
 # server - nginx alpine
-FROM nginx:stable-alpine as server
+FROM nginxinc/nginx-unprivileged:stable-alpine as server
 COPY --from=builder /build/build /usr/share/nginx/html
 COPY nginx-default.conf /etc/nginx/templates/default.conf.template
 ENV KEYCLOAK_HOST "http://localhost/keycloak/auth"
@@ -29,4 +29,4 @@ ENV ENTITLEMENTS_HOST "http://localhost/entitlements"
 ENV KAS_HOST "http://localhost:8000"
 ENV SERVER_BASE_PATH ""
 
-EXPOSE 80
+EXPOSE 8080

--- a/charts/abacus/templates/_helpers.tpl
+++ b/charts/abacus/templates/_helpers.tpl
@@ -60,3 +60,49 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create URL to attributes service
+*/}}
+{{- define "abacus.attributesServerUrl" -}}
+{{- if .Values.attributes.serverUrl }}
+{{- .Values.attributes.serverUrl }}
+{{- else }}
+{{- printf "%s://%s%s" .Values.global.opentdf.common.ingress.scheme .Values.global.opentdf.common.ingress.hostname .Values.global.opentdf.common.ingress.attributesPrefix }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create URL to entitlements service
+*/}}
+{{- define "abacus.entitlementsServerUrl" -}}
+{{- if .Values.entitlements.serverUrl  }}
+{{- .Values.entitlements.serverUrl  }}
+{{- else }}
+{{- printf "%s://%s%s" .Values.global.opentdf.common.ingress.scheme .Values.global.opentdf.common.ingress.hostname .Values.global.opentdf.common.ingress.entitlementsPrefix }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create URL to key access service
+*/}}
+{{- define "abacus.kasServerUrl" -}}
+{{- if .Values.kas.serverUrl  }}
+{{- .Values.kas.serverUrl  }}
+{{- else }}
+{{- printf "%s://%s%s" .Values.global.opentdf.common.ingress.scheme .Values.global.opentdf.common.ingress.hostname .Values.global.opentdf.common.ingress.kasPrefix }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create URL to Keycloak Endpoint
+*/}}
+{{- define "abacus.keycloakServerUrl" -}}
+{{- if .Values.oidc.serverUrl }}
+{{- .Values.oidc.serverUrl }}
+{{- else }}
+{{- printf "%s/auth/" .Values.global.opentdf.common.oidcExternalBaseUrl }}
+{{- end }}
+{{- end }}
+
+

--- a/charts/abacus/templates/configmap.yaml
+++ b/charts/abacus/templates/configmap.yaml
@@ -3,10 +3,10 @@ kind: ConfigMap
 metadata:
   name: {{ include "abacus.name" . }}-cm
 data:
-  KEYCLOAK_HOST: {{ .Values.oidc.serverUrl | quote }}
+  KEYCLOAK_HOST: {{ include "abacus.keycloakServerUrl" . | quote }}
   KEYCLOAK_CLIENT_ID: {{ .Values.oidc.clientId | quote }}
   KEYCLOAK_REALMS: {{ .Values.oidc.queryRealms | quote }}
-  ATTRIBUTES_HOST: {{ .Values.attributes.serverUrl | quote }}
-  ENTITLEMENTS_HOST: {{ .Values.entitlements.serverUrl | quote }}
+  ATTRIBUTES_HOST: {{ include "abacus.attributesServerUrl" . | quote }}
+  ENTITLEMENTS_HOST: {{ include "abacus.entitlementsServerUrl" . | quote }}
   SERVER_BASE_PATH: {{ .Values.basePath | quote }}
-  KAS_HOST: {{ .Values.kas.serverUrl | quote }}
+  KAS_HOST: {{ include "abacus.kasServerUrl" . | quote }}

--- a/charts/abacus/templates/deployment.yaml
+++ b/charts/abacus/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
                 name: {{ include "abacus.name" . }}-cm
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/abacus/values.yaml
+++ b/charts/abacus/values.yaml
@@ -3,12 +3,16 @@
 # Declare variables to be passed into your templates.
 
 attributes:
+  # Overrides global.opentdf.common.oidcExternalBaseUrl + global.opentdf.common.oidcExternalBaseUrl
   serverUrl: "http://localhost:65432/api/attributes/"
 entitlements:
+  # Overrides global.opentdf.common.oidcExternalBaseUrl + global.opentdf.common.oidcExternalBaseUrl
   serverUrl: "http://localhost:65432/api/entitlements/"
 kas:
+  # Overrides global.opentdf.common.oidcExternalBaseUrl + global.opentdf.common.oidcExternalBaseUrl
   serverUrl: "http://localhost:65432/api/kas"
 oidc:
+  # Overrides global.opentdf.common.oidcExternalBaseUrl + /auth/
   serverUrl: "http://localhost:65432/auth/"
   clientId: "dcr-test"
   # Comma separated list of realms to allow access to in keycloak
@@ -55,7 +59,7 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8080
 
 ingress:
   enabled: true

--- a/nginx-default.conf
+++ b/nginx-default.conf
@@ -1,6 +1,6 @@
 # processed as a .template, uses environmnent variables from Dockerfile
 server {
-    listen 80;
+    listen 8080;
     add_header Content-Security-Policy frame-ancestors;
     add_header  X-Content-Type-Options nosniff;
     location / {


### PR DESCRIPTION
- Update to [nginxinc's image](https://hub.docker.com/r/nginxinc/nginx-unprivileged)
- Use global values to parameterize openTDF service endpoints.