### PR TITLE
🐛 Allows appVersion to set tag

### DIFF
--- a/charts/abacus/Chart.yaml
+++ b/charts/abacus/Chart.yaml
@@ -3,4 +3,4 @@ name: abacus
 description: TDF administration web application
 type: application
 version: 0.1.0
-appVersion: "0.1.0"
+appVersion: main

--- a/charts/abacus/values.yaml
+++ b/charts/abacus/values.yaml
@@ -29,7 +29,7 @@ image:
   repository: ghcr.io/opentdf/abacus
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: main
+  # tag: main
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
- Previously, we defaulted to main explicitly
- on publish, this will update appVersion to current tag