### PR TITLE
base path fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY src/ src/
 COPY tests/ tests/
 COPY tsconfig.json/ .
 COPY craco.config.js/ .
+RUN npm pkg set 'homepage'='%REACT_APP_SERVER_BASE_PATH%'
 RUN npm run build
 
 # gobuilder - http server build

--- a/public/index.html
+++ b/public/index.html
@@ -5,14 +5,14 @@
     <script>
       window.SERVER_DATA = %REACT_APP_SERVER_DATA%;
     </script>
-    <link rel="icon" href="favicon.ico" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="manifest.json" />
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
@@ -23,7 +23,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Abacus</title>
-    <base href="/">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/server/main.go
+++ b/server/main.go
@@ -60,6 +60,14 @@ func main() {
 	if string(input) == output {
 		log.Fatalln("replacing failed")
 	}
+	// replace /%REACT_APP_SERVER_BASE_PATH% in index file
+	r := regexp.MustCompile("/%REACT_APP_SERVER_BASE_PATH%")
+	basePath := os.Getenv("SERVER_BASE_PATH")
+	// make sure there is no double-slash
+	if basePath == "/" {
+		basePath = ""
+	}
+	output = r.ReplaceAllString(output, basePath)
 	log.Println("replaced")
 	// serve replaced index.html instead of writing it (permission issue)
 	fs := http.FileServer(http.Dir(directory))


### PR DESCRIPTION
https://virtru.atlassian.net/browse/PLAT-2032 -- SERVER_BASE_PATH not used in `static` endpoints
- replaces ENV SERVER_BASE_PATH at container start time
  - sets intermediate REACT_APP_SERVER_BASE_PATH using `homepage` in package.json
  - create-react-app also replaces PUBLIC_URL with `homepage`