### PR TITLE
set REACT_APP_SERVER_DATA explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "start": "craco start",
     "start:test": "cross-env REACT_APP_TEST_MODE=1 craco start",
-    "build": "craco build",
+    "build": "REACT_APP_SERVER_DATA=%REACT_APP_SERVER_DATA% craco build",
     "build:test": "REACT_APP_SERVER_DATA=__SERVER_DATA__ cross-env REACT_APP_TEST_MODE=1 craco build",
     "test": "craco test --coverage",
     "test:prod": "craco test --watchAll=false",


### PR DESCRIPTION
PLAT-2203
- `.env.local` was still being picked up
- explicitly set `REACT_APP_SERVER_DATA` to the expected value the Go http server expects during container startup