### PR TITLE
🐛 fixes git is-ancestor check for release tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,8 @@ jobs:
       VERSION: ${{ steps.version.outputs.VERSION }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
@@ -26,8 +28,6 @@ jobs:
       - run: |
           git remote -v
           git branch -v
-      - run: |
-          git pull origin main
       - run: |
           git merge-base --is-ancestor HEAD main && echo main before head
           if ! git merge-base --is-ancestor "$tag" origin/main; then

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,36 +25,6 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
           echo "$GITHUB_CONTEXT"
-      - run: |
-          git remote -v
-          git branch -v
-          git fetch origin main:main
-          git fetch --all --tags
-          git branch -v
-      - run: |
-          git merge-base --is-ancestor HEAD main && echo main before head
-          if ! git merge-base --is-ancestor "$tag" main; then
-            if git merge-base --is-ancestor main "$tag"; then
-              echo "# Invalid release tag [$tag] - ahead of `main` branch" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "# Invalid release tag [$tag] - must be on `main` branch" >> $GITHUB_STEP_SUMMARY
-            fi
-            exit 1
-          fi
-        env:
-          tag: "1.2.0"
-      - run: |
-          git merge-base --is-ancestor HEAD main && echo main before head
-          if ! git merge-base --is-ancestor "$tag" origin/main; then
-            if git merge-base --is-ancestor origin/main "$tag"; then
-              echo "# Invalid release tag [$tag] - ahead of `main` branch" >> $GITHUB_STEP_SUMMARY
-            else
-              echo "# Invalid release tag [$tag] - must be on `main` branch" >> $GITHUB_STEP_SUMMARY
-            fi
-            exit 1
-          fi
-        env:
-          tag: "${{ github.head_ref }}"
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -104,6 +74,10 @@ jobs:
         if: ${{ !!github.event.release }}
         name: Validate release tag matches package version
       - run: |
+          git fetch origin main:main
+          git fetch --all --tags
+          git branch -v
+          git tag
           if ! git merge-base --is-ancestor "$tag" main; then
             echo "# Invalid release tag [$tag] - must be on `main` branch" >> $GITHUB_STEP_SUMMARY
             exit 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,12 +29,12 @@ jobs:
           git remote -v
           git branch -v
           git fetch origin main:main
-          git fetch origin 1.2.0:1.2.0
+          git fetch --all --tags
           git branch -v
       - run: |
           git merge-base --is-ancestor HEAD main && echo main before head
-          if ! git merge-base --is-ancestor "$tag" origin/main; then
-            if git merge-base --is-ancestor origin/main "$tag"; then
+          if ! git merge-base --is-ancestor "$tag" main; then
+            if git merge-base --is-ancestor main "$tag"; then
               echo "# Invalid release tag [$tag] - ahead of `main` branch" >> $GITHUB_STEP_SUMMARY
             else
               echo "# Invalid release tag [$tag] - must be on `main` branch" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,9 @@ jobs:
           git remote -v
           git branch -v
       - run: |
+          git pull origin main
+      - run: |
+          git merge-base --is-ancestor HEAD main && echo main before head
           if ! git merge-base --is-ancestor "$tag" origin/main; then
             if git merge-base --is-ancestor origin/main "$tag"; then
               echo "# Invalid release tag [$tag] - ahead of `main` branch" >> $GITHUB_STEP_SUMMARY
@@ -206,6 +209,7 @@ jobs:
 
   dispatch:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'opentdf/frontend' }}
     steps:
       - name: Trigger opentdf/tests
         run: >-

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,21 @@ jobs:
       VERSION: ${{ steps.version.outputs.VERSION }}
     steps:
       - uses: actions/checkout@v3
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
+      - run: |
+          git remote -v
+          git branch -v
+      - run: |
+          if ! git merge-base --is-ancestor "$tag" origin/main; then
+            echo "# Invalid release tag [$tag] - must be on `main` branch" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+        env:
+          tag: "${{ github.event.push.branch }}"
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,21 @@ jobs:
       - run: |
           git remote -v
           git branch -v
+          git fetch origin main:main
+          git fetch origin 1.2.0:1.2.0
+          git branch -v
+      - run: |
+          git merge-base --is-ancestor HEAD main && echo main before head
+          if ! git merge-base --is-ancestor "$tag" origin/main; then
+            if git merge-base --is-ancestor origin/main "$tag"; then
+              echo "# Invalid release tag [$tag] - ahead of `main` branch" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "# Invalid release tag [$tag] - must be on `main` branch" >> $GITHUB_STEP_SUMMARY
+            fi
+            exit 1
+          fi
+        env:
+          tag: "1.2.0"
       - run: |
           git merge-base --is-ancestor HEAD main && echo main before head
           if ! git merge-base --is-ancestor "$tag" origin/main; then

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,11 +28,15 @@ jobs:
           git branch -v
       - run: |
           if ! git merge-base --is-ancestor "$tag" origin/main; then
-            echo "# Invalid release tag [$tag] - must be on `main` branch" >> $GITHUB_STEP_SUMMARY
+            if git merge-base --is-ancestor origin/main "$tag"; then
+              echo "# Invalid release tag [$tag] - ahead of `main` branch" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "# Invalid release tag [$tag] - must be on `main` branch" >> $GITHUB_STEP_SUMMARY
+            fi
             exit 1
           fi
         env:
-          tag: "${{ github.event.push.branch }}"
+          tag: "${{ github.head_ref }}"
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,11 +20,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          echo "$GITHUB_CONTEXT"
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
- Adding `fetch-depth: 0` gets additional objects from git db including the any branches we need
- `git fetch main:main` will initialize a tracking branch called main that tracks the remote (origin) main
- `git fetch --all --tags` will fetch the tags
- includes some debugging output
- Checks for common problem where we are tagging a feature or release branch
- While I'm here, modify 'dispatch' event to opentdf/tests to only happen on pushes to main