### PR TITLE
Integrate recent improvement to existed Playwright tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       },
       "devDependencies": {
         "@craco/craco": "^7.0.0-alpha.0",
-        "@playwright/test": "^1.23.3",
+        "@playwright/test": "^1.27.2",
         "@testing-library/jest-dom": "~5.14.1",
         "@testing-library/react": "~11.2.7",
         "@testing-library/user-event": "~12.8.3",
@@ -3051,13 +3051,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.3.tgz",
-      "integrity": "sha512-kR4vo2UGHC84DGqE6EwvAeaehj3xCAK6LoC1P1eu6ZGdC79rlqRKf8cFDx6q6c9T8MQSL1O9eOlup0BpwqNF0w==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0.tgz",
+      "integrity": "sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.23.3"
+        "playwright-core": "1.30.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -12599,9 +12599,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.3.tgz",
-      "integrity": "sha512-x35yzsXDyo0BIXYimLnUFNyb42c//NadUNH6IPGOteZm96oTGA1kn4Hq6qJTI1/f9wEc1F9O1DsznXIgXMil7A==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
+      "integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -19870,13 +19870,13 @@
       }
     },
     "@playwright/test": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.3.tgz",
-      "integrity": "sha512-kR4vo2UGHC84DGqE6EwvAeaehj3xCAK6LoC1P1eu6ZGdC79rlqRKf8cFDx6q6c9T8MQSL1O9eOlup0BpwqNF0w==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0.tgz",
+      "integrity": "sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.23.3"
+        "playwright-core": "1.30.0"
       }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
@@ -26977,9 +26977,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.3.tgz",
-      "integrity": "sha512-x35yzsXDyo0BIXYimLnUFNyb42c//NadUNH6IPGOteZm96oTGA1kn4Hq6qJTI1/f9wEc1F9O1DsznXIgXMil7A==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
+      "integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==",
       "dev": true
     },
     "postcss": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@craco/craco": "^7.0.0-alpha.0",
-    "@playwright/test": "^1.23.3",
+    "@playwright/test": "^1.27.2",
     "@testing-library/jest-dom": "~5.14.1",
     "@testing-library/react": "~11.2.7",
     "@testing-library/user-event": "~12.8.3",

--- a/tests/e2e/App.spec.ts
+++ b/tests/e2e/App.spec.ts
@@ -19,11 +19,12 @@ test.describe('<App/>', () => {
   });
 
   test('should be able to log out on the Attributes page', async ({ page }) => {
-    await page.goto('/attributes');
-    await Promise.all([
-      page.waitForNavigation(),
-      page.click(selectors.logoutButton),
-    ])
+    await test.step('Open Attributes route', async () => {
+      await page.getByRole('link', { name: 'Attributes' }).click();
+      await page.waitForURL('**/attributes');
+    });
+
+    await page.click(selectors.logoutButton)
     await page.waitForSelector(selectors.loginButton);
     // check that data isn't shown
     const authorityDropdown = page.locator(".ant-select-selector >> nth=1")
@@ -32,14 +33,15 @@ test.describe('<App/>', () => {
   });
 
   test('should be able to log out on the Authorities page', async ({ page }) => {
-    await page.goto('/authorities');
+    await test.step('Open Authorities route', async () => {
+      await page.getByRole('link', { name: 'Authorities' }).click();
+      await page.waitForURL('**/authorities');
+    });
+
     // check that authority items are present when logged in
     await expect(page.locator(selectors.authoritiesPage.deleteAuthorityButton)).toBeVisible()
 
-    await Promise.all([
-      page.waitForNavigation(),
-      page.click(selectors.logoutButton),
-    ])
+    await page.click(selectors.logoutButton)
     await page.waitForSelector(selectors.loginButton);
     // check that authorities data isn't shown after log out
     const noDataInfo = page.locator(".ant-empty-description", {hasText: 'No Data'})
@@ -47,11 +49,12 @@ test.describe('<App/>', () => {
   });
 
   test('should be able to log out on the Entitlements page', async ({ page }) => {
-    await page.goto('/entitlements');
-    await Promise.all([
-      page.waitForNavigation(),
-      page.click(selectors.logoutButton),
-    ])
+    await test.step('Open Entitlements route', async () => {
+      await page.getByRole('link', { name: 'Entitlements' }).click();
+      await page.waitForURL('**/entitlements');
+    });
+
+    await page.click(selectors.logoutButton)
     await page.waitForSelector(selectors.loginButton);
 
     // check that entities data isn't shown after log out - progress indicator is shown constantly
@@ -62,18 +65,16 @@ test.describe('<App/>', () => {
   });
 
   test('should be able to log out on the Entity Details page', async ({ page }) => {
-    await page.goto('/entitlements');
-    await Promise.all([
-      page.waitForNavigation(),
-      firstTableRowClick('users-table', page),
-    ]);
+    await test.step('Open Entitlements route', async () => {
+      await page.getByRole('link', { name: 'Entitlements' }).click();
+      await page.waitForURL('**/entitlements');
+    });
+
+    await firstTableRowClick('users-table', page),
     // check that entitlement items are present when logged in
     await expect(page.locator(selectors.entitlementsPage.entityDetailsPage.deleteEntitlementBtn)).toBeVisible()
 
-    await Promise.all([
-      page.waitForNavigation(),
-      page.click(selectors.logoutButton),
-    ])
+    await page.click(selectors.logoutButton)
     await page.waitForSelector(selectors.loginButton);
     // check that entitlement data isn't shown after log out
     const noDataInfo = page.locator(".ant-empty-description", {hasText: 'No Data'})
@@ -96,7 +97,7 @@ test.describe('<Login/>', () => {
     await authorize(page, "/attributes")
 
     await test.step('check that Attributes data is loaded', async () => {
-      const attributeItems = await page.$$(selectors.attributesPage.attributeListItems)
+      const attributeItems = await page.locator(selectors.attributesPage.attributeListItems).all();
       const itemsQuantity = attributeItems.length
       await expect(itemsQuantity>1).toBeTruthy()
     })
@@ -106,13 +107,13 @@ test.describe('<Login/>', () => {
     await authorize(page, "/entitlements")
 
     await test.step('check that Clients data is loaded', async () => {
-      const clientsTableItems = await page.$$(`[data-test-id='clients-table'] .ant-table-row`);
+      const clientsTableItems = await page.locator(`[data-test-id='clients-table'] .ant-table-row`).all();
       const clientsItemsQuantity = clientsTableItems.length
       await expect(clientsItemsQuantity>0).toBeTruthy()
     })
 
     await test.step('check that Users data is loaded', async () => {
-      const usersTableItems = await page.$$(`[data-test-id='users-table'] .ant-table-row`);
+      const usersTableItems = await page.locator(`[data-test-id='users-table'] .ant-table-row`).all();
       const usersItemsQuantity = usersTableItems.length
       await expect(usersItemsQuantity>0).toBeTruthy()
     })
@@ -122,17 +123,11 @@ test.describe('<Login/>', () => {
   test.skip('succeeded on the Entity Details page, actual data is loaded', async ({ page }) => {
     await authorize(page, "/entitlements")
 
-    await Promise.all([
-      page.waitForNavigation(),
-      firstTableRowClick('users-table', page),
-    ]);
+    await firstTableRowClick('users-table', page)
 
     const entityId = await getLastPartOfUrl(page)
 
-    await Promise.all([
-      page.waitForNavigation(),
-      page.click(selectors.logoutButton),
-    ])
+    await page.click(selectors.logoutButton)
 
     await authorize(page, `/entitlements/users/${entityId}`)
     await expect(page.locator(selectors.entitlementsPage.entityDetailsPage.deleteEntitlementBtn)).toBeVisible()

--- a/tests/e2e/Authorities.spec.ts
+++ b/tests/e2e/Authorities.spec.ts
@@ -6,7 +6,7 @@ import {
     assertAttributeCreatedMsg,
     getAccessToken,
     deleteAuthorityViaAPI,
-    deleteAttributeViaAPI
+    removeAllAttributesOfAuthority
 } from './helpers/operations';
 import { test } from './helpers/fixtures';
 import { selectors } from "./helpers/selectors";
@@ -19,9 +19,9 @@ test.describe('<Authorities/>', () => {
         await authorize(page);
         authToken = await getAccessToken(page)
 
-        await page.goto('/attributes');
-        // click the token message to close it and overcome potential overlapping problem
-        await page.locator(selectors.tokenMessage).click()
+        await page.getByRole('link', { name: 'Attributes' }).click();
+        await page.waitForURL('**/attributes');
+
         await createAuthority(page, authority);
         // click success message to close it and overcome potential overlapping problem
         const authorityCreatedMsg = page.locator(selectors.alertMessage, {hasText:'Authority was created'})
@@ -34,37 +34,47 @@ test.describe('<Authorities/>', () => {
         });
     });
 
+    test.afterEach(async ({ authority}, testInfo) => {
+        // Because authority in this test already deleted
+        await removeAllAttributesOfAuthority(apiContext, authority);
+        if (testInfo.title !== 'delete authority if there are no assigned attributes') {
+            await deleteAuthorityViaAPI(apiContext, authority);
+        }
+    })
+
     test.afterAll(async ({ }) => {
         await apiContext.dispose();
     });
 
     test('renders initially', async ({ page, authority}) => {
-        await page.goto('/authorities');
+        await page.getByRole('link', { name: 'Authorities' }).click();
+        await page.waitForURL('**/authorities');
+
         const header = page.locator(selectors.authoritiesPage.header, { hasText: "Authorities" });
         await expect(header).toBeVisible();
-
-        await test.step('Cleanup', async() => {
-            await deleteAuthorityViaAPI(apiContext, authority)
-        })
     });
 
     test('delete authority if there are no assigned attributes', async ({ page, authority}) => {
-        await page.goto('/authorities');
-        // click the token message to close it and overcome potential overlapping problem
-        await page.locator(selectors.tokenMessage).click()
+        await test.step('Open Authorities route', async () => {
+            await page.getByRole('link', { name: 'Authorities' }).click();
+            await page.waitForURL('**/authorities');
+        });
 
-        const originalTableRows = await page.$$(selectors.authoritiesPage.authoritiesTableRow)
+        await page.waitForSelector(selectors.authoritiesPage.authoritiesTableRow);
+        const originalTableRows = await page.locator(selectors.authoritiesPage.authoritiesTableRow).all()
         const originalTableSize = originalTableRows.length
 
-        const deleteAuthorityButtonForTheLastRowItem = await page.locator('#delete-authority-button >> nth=-1')
-        await deleteAuthorityButtonForTheLastRowItem.click()
+        const deleteAuthorityButton = await page.getByRole('row', { name: `${authority} Delete` }).getByRole('button', { name: 'Delete' });
+        await deleteAuthorityButton.click();
 
         await test.step('Should be able to close the dialog and cancel authority removal', async() => {
             await page.click(selectors.authoritiesPage.confirmDeletionModal.cancelDeletionBtn)
         })
 
-        await deleteAuthorityButtonForTheLastRowItem.click()
-        await page.click(selectors.authoritiesPage.confirmDeletionModal.confirmDeletionBtn)
+        await test.step('Confirm Deletion Modal', async () => {
+            await deleteAuthorityButton.click();
+            await page.click(selectors.authoritiesPage.confirmDeletionModal.confirmDeletionBtn)
+        });
 
         await test.step('Assert success message', async() => {
             const successfulDeletionMsg = await page.locator(selectors.alertMessage, {hasText: `Authority ${authority} deleted`})
@@ -72,7 +82,7 @@ test.describe('<Authorities/>', () => {
             await successfulDeletionMsg.click()
         })
 
-        const updatedTableRows = await page.$$(selectors.authoritiesPage.authoritiesTableRow)
+        const updatedTableRows = await page.locator(selectors.authoritiesPage.authoritiesTableRow).all()
         const updatedTableSize = updatedTableRows.length
 
         expect(updatedTableSize === (originalTableSize - 1)).toBeTruthy()
@@ -81,9 +91,11 @@ test.describe('<Authorities/>', () => {
     test('Authority removal is failed when contains assigned attributes', async ({ page, authority, attributeName, attributeValue}) => {
         await createAttribute(page, attributeName, [attributeValue])
         await assertAttributeCreatedMsg(page)
-        await page.goto('/authorities');
-        // click the token message to close it and overcome potential overlapping problem
-        await page.locator(selectors.tokenMessage).click()
+
+        await test.step('Open Authorities route', async () => {
+            await page.getByRole('link', { name: 'Authorities' }).click();
+            await page.waitForURL('**/authorities');
+        });
 
         const deleteAuthorityButtonForTheLastRowItem = await page.locator('#delete-authority-button >> nth=-1')
         await deleteAuthorityButtonForTheLastRowItem.click()
@@ -93,11 +105,6 @@ test.describe('<Authorities/>', () => {
             const removalFailedMsg = await page.locator(selectors.alertMessage, {hasText: `Something went wrong`})
             await expect(removalFailedMsg).toBeVisible()
             await removalFailedMsg.click()
-        })
-
-        await test.step('Cleanup', async() => {
-            await deleteAttributeViaAPI(apiContext, authority, attributeName, [attributeValue])
-            await deleteAuthorityViaAPI(apiContext, authority)
         })
     });
 });

--- a/tests/e2e/Entitlements.spec.ts
+++ b/tests/e2e/Entitlements.spec.ts
@@ -1,4 +1,4 @@
-import {APIRequestContext, expect} from '@playwright/test';
+import { APIRequestContext, expect } from '@playwright/test';
 import {
   createAuthority,
   firstTableRowClick,
@@ -8,7 +8,7 @@ import {
   getAccessToken
 } from './helpers/operations';
 import { test } from './helpers/fixtures';
-import {selectors} from "./helpers/selectors";
+import { selectors } from "./helpers/selectors";
 
 let authToken: string | null;
 let apiContext: APIRequestContext;
@@ -18,16 +18,16 @@ test.describe('<Entitlements/>', () => {
     await authorize(page);
     authToken = await getAccessToken(page)
 
-    await page.goto('/attributes');
-    // click the token message to close it and overcome potential overlapping problem
-    await page.locator(selectors.tokenMessage).click()
+    await page.getByRole('link', { name: 'Attributes' }).click();
+    await page.waitForURL('**/attributes');
+
     await createAuthority(page, authority);
     // click success message to close it and overcome potential overlapping problem
     const authorityCreatedMsg = page.locator(selectors.alertMessage, {hasText:'Authority was created'})
     await authorityCreatedMsg.click()
-    await page.goto('/entitlements');
-    // click the token message to close it and overcome potential overlapping problem
-    await page.locator(selectors.tokenMessage).click()
+
+    await page.getByRole('link', { name: 'Entitlements' }).click();
+    await page.waitForURL('**/entitlements');
 
     apiContext = await playwright.request.newContext({
       extraHTTPHeaders: {
@@ -53,10 +53,7 @@ test.describe('<Entitlements/>', () => {
   });
 
   test('redirect to user/PE', async ({ page }) => {
-    await Promise.all([
-        page.waitForNavigation(),
-        firstTableRowClick('users-table', page),
-    ]);
+    await firstTableRowClick('users-table', page)
 
     const id = getLastPartOfUrl(page);
     const header = page.locator(selectors.secondaryHeader, { hasText: `User ${id}` });
@@ -64,10 +61,7 @@ test.describe('<Entitlements/>', () => {
   });
 
   test('redirect to client/NPE', async ({ page }) => {
-    await Promise.all([
-        page.waitForNavigation(),
-        firstTableRowClick('clients-table', page),
-    ]);
+    await firstTableRowClick('clients-table', page)
 
     const id = getLastPartOfUrl(page);
     const header = page.locator(selectors.secondaryHeader, { hasText: `Client ${id}` });
@@ -75,10 +69,7 @@ test.describe('<Entitlements/>', () => {
   });
 
   test('Add Entitlements To Entity', async ({ page , authority, attributeName, attributeValue}) => {
-    await Promise.all([
-        page.waitForNavigation(),
-        firstTableRowClick('clients-table', page),
-    ]);
+    await firstTableRowClick('clients-table', page)
 
     await test.step('Entitle attribute', async() => {
       await page.type(selectors.entitlementsPage.authorityNamespaceField, authority);

--- a/tests/e2e/api.spec.ts
+++ b/tests/e2e/api.spec.ts
@@ -1,5 +1,5 @@
 import { test } from './helpers/fixtures';
-import { APIRequestContext, chromium, expect, Page } from "@playwright/test";
+import { APIRequestContext, expect, Page } from "@playwright/test";
 import { selectors } from "./helpers/selectors";
 import {deleteAttributeViaAPI, deleteAuthorityViaAPI, getAccessToken} from "./helpers/operations";
 
@@ -7,14 +7,18 @@ let apiContext: APIRequestContext;
 let pageContext;
 
 const getAccessTokenAfterLogin = async (page: Page) => {
-    await page.goto('http://localhost:3000/');
+    const responsePromise = page.waitForResponse('**/token');
+
+    await page.goto('/');
     await page.locator(selectors.loginButton).click()
     await page.fill(selectors.loginScreen.usernameField, "user1");
     await page.fill(selectors.loginScreen.passwordField, "testuser123");
     await page.click(selectors.loginScreen.submitButton);
 
-    await page.waitForResponse('**/token');
-    return await getAccessToken(page)
+    const response = await responsePromise;
+    const jsonResponse = await response.json();
+
+    return jsonResponse.access_token;
 };
 
 test.describe('API:', () => {

--- a/tests/e2e/helpers/operations.ts
+++ b/tests/e2e/helpers/operations.ts
@@ -22,6 +22,7 @@ export const authorize = async (page: Page, sectionUrl = "/") => {
 };
 
 export const createAuthority = async (page: Page, authority: any) => {
+  await page.waitForSelector(selectors.attributesPage.newSectionBtn);
   await page.locator(selectors.attributesPage.newSectionBtn).click();
   await page.fill(selectors.attributesPage.newSection.authorityField, authority);
   await page.locator(selectors.attributesPage.newSection.submitAuthorityBtn).click();
@@ -59,6 +60,25 @@ export const getAccessToken = async (page: Page) => {
   });
 };
 
+export const createAttributeViaAPI = async (
+    apiContext: APIRequestContext,
+    authority: string,
+    attrName: string,
+    attrOrder: string[],
+    attrRule: string
+) => {
+  const createAttributeResponse = await apiContext.post('http://localhost:65432/api/attributes/definitions/attributes', {
+    data: {
+      "authority": authority,
+      "name": attrName,
+      "rule": attrRule,
+      "state": "published",
+      "order": attrOrder
+    }
+  })
+  expect(createAttributeResponse.ok()).toBeTruthy()
+}
+
 export const deleteAttributeViaAPI = async (apiContext: APIRequestContext, authority: string, attrName: string, attrOrder: string[], attrRule = "hierarchy", attrState = "published") => {
   const deleteAttributeResponse = await apiContext.delete('http://localhost:65432/api/attributes/definitions/attributes', {
     data: {
@@ -70,6 +90,20 @@ export const deleteAttributeViaAPI = async (apiContext: APIRequestContext, autho
     }
   })
   expect(deleteAttributeResponse.ok()).toBeTruthy()
+};
+
+export const removeAllAttributesOfAuthority = async (apiContext: APIRequestContext, authority: string) => {
+  const response = await apiContext.get(`http://localhost:65432/api/attributes/definitions/attributes?authority=${authority}`);
+  const attributes = await response.json();
+
+  if (attributes.length > 0) {
+    return await Promise.all(attributes.map(async (item: any) => {
+      const mockExampleAuthority = 'https://example.com';
+      if (!item.name.includes(mockExampleAuthority)) {
+        await deleteAttributeViaAPI(apiContext, authority, item.name, item.order, item.rule, item.state);
+      }
+    }))
+  }
 };
 
 export const deleteAuthorityViaAPI = async (apiContext: APIRequestContext, authority: string) => {

--- a/tests/e2e/helpers/selectors.ts
+++ b/tests/e2e/helpers/selectors.ts
@@ -72,7 +72,7 @@ export const selectors = {
     authoritiesPage: {
         header: '.ant-page-header-heading-title',
         authoritiesTableRow: '.ant-table-row',
-        deleteAuthorityButton: '#delete-authority-button',
+        deleteAuthorityButton: '#delete-authority-button >> nth=0',
         confirmDeletionModal: {
             cancelDeletionBtn: '#cancel-deletion',
             confirmDeletionBtn: '#delete-authority',

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,7 +1,4 @@
 import { PlaywrightTestConfig, devices } from '@playwright/test';
-import dotenv from "dotenv";
-// @ts-ignore
-dotenv.config({ multiline: true });
 
 /* See https://playwright.dev/docs/test-configuration. */
 const config: PlaywrightTestConfig = {
@@ -27,7 +24,7 @@ const config: PlaywrightTestConfig = {
     browserName: "chromium",
     headless: !false,
     launchOptions: {
-      slowMo: 50,
+      slowMo: 500,
     }
   },
   expect: {
@@ -38,7 +35,7 @@ const config: PlaywrightTestConfig = {
     timeout: 5000
   },
   /* Maximum time one test can run for. */
-  timeout: 30 * 1000,
+  timeout: 3 * 60 * 1000,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? 'line' : 'html',
   /* Configure projects for major browsers */


### PR DESCRIPTION
- Playwright update to 1.30 
- improved tests cleanup, 
- get rid of deprecated $$ selectors and waitForNavigation methods
- navigation improvements

PLAT-2301